### PR TITLE
紙・段ボールの使用可能表記を削除

### DIFF
--- a/doc/LaserCutter1.md
+++ b/doc/LaserCutter1.md
@@ -28,15 +28,16 @@ Aizu Geek Dojoには２台のレーザーカッターがあります。
 #### 加工できる素材
 AizuGeekDojoにあるレーザーカッターでは主に以下の材料を加工することができます。
 
-| 紙、ダンボール | アクリル板 | MDF | レーザー加工用スタンプゴム | 皮革 |
-| :---------: | :-------:| :-----: | :--------------: | :-----: |
-|![cardboard](./image/cardboard.jpg)|![acril](./image/acrylic.jpg)|![MDF](./image/mdf.jpg)|![gum](./image/gum.jpg)|![leather](./image/leather.jpg)|
+| アクリル板 | MDF | レーザー加工用スタンプゴム | 皮革 |
+| :-------:| :-----: | :--------------: | :-----: |
+|![acril](./image/acrylic.jpg)|![MDF](./image/mdf.jpg)|![gum](./image/gum.jpg)|![leather](./image/leather.jpg)|
 
-- 紙、段ボール
 - アクリル板
 - MDF
 - レーザー加工用スタンプゴム
 - 皮革
+  
+(紙・段ボールの加工は禁止となりました。)
 
 それ以外の材料は加工ができない、または加工時に有毒なガスが発生することがあるため使用しないでください。
 


### PR DESCRIPTION
Removed paper and cardboard from the list of materials that can be processed and added a note about the prohibition.