### PR TITLE
JobControlXのpdfを削除

### DIFF
--- a/doc/参考になるページ.md
+++ b/doc/参考になるページ.md
@@ -1,6 +1,3 @@
 # 参考になるリンク集
 
-[Trotec 加工マニュアル、illustrator CCからJobControlXまで](https://www.troteclaser.com/fileadmin/content/images/Contact_Support/Manuals/FirstLaser-Illustrator-JC10-v4.pdf)
-
 [Adobe イラストレーターチュートリアル](https://helpx.adobe.com/jp/illustrator/how-to/what-is-illustrator.html)
-


### PR DESCRIPTION
Removed Trotec manual link from reference page.